### PR TITLE
Added (rough draft of) LinkedListPipeStream.

### DIFF
--- a/LinkedListPipeStream.cs
+++ b/LinkedListPipeStream.cs
@@ -1,0 +1,188 @@
+using System;
+using System.IO;
+using System.Threading;
+
+namespace Renci.SshNet.Common
+{
+    internal class LinkedListPipeStream : Stream
+    {
+        private PipeEntry _first;
+        private PipeEntry _last;
+        private bool _isDisposed;
+        private readonly object _lock;
+
+        public LinkedListPipeStream()
+        {
+            _lock = new object();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+            if (offset + count > buffer.Length)
+                throw new ArgumentException("The sum of offset and count is greater than the buffer length.");
+            if (offset < 0 || count < 0)
+                throw new ArgumentOutOfRangeException("offset", "offset or count is negative.");
+
+            lock (_lock)
+            {
+                var totalBytesRead = 0;
+
+                while (count > 0)
+                {
+                    while (_first == null && !_isDisposed)
+                        Monitor.Wait(_lock);
+
+                    if (_first == null)
+                    {
+                        return totalBytesRead;
+                    }
+
+                    var bytesRead = _first.Read(buffer, offset, count);
+                    if (_first.IsEmpty)
+                    {
+                        _first = _first.Next;
+                    }
+
+                    count -= bytesRead;
+                    totalBytesRead += bytesRead;
+                    offset += bytesRead;
+                }
+
+                return totalBytesRead;
+            }
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+            if (offset + count > buffer.Length)
+                throw new ArgumentException("The sum of offset and count is greater than the buffer length.");
+            if (offset < 0 || count < 0)
+                throw new ArgumentOutOfRangeException("offset", "offset or count is negative.");
+            if (_isDisposed)
+                throw CreateObjectDisposedException();
+            if (count == 0)
+                return;
+
+            lock (_lock)
+            {
+                var last = new PipeEntry(buffer, offset, count);
+                if (_last == null)
+                    _last = last;
+                else
+                {
+                    _last = _last.Next = last;
+                }
+
+                if (_first == null)
+                {
+                    _first = _last;
+                }
+
+                Monitor.Pulse(_lock);
+            }
+        }
+
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override long Position { get; set; }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the Stream and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        /// <remarks>
+        /// Disposing a <see cref="PipeStream"/> will interrupt blocking read and write operations.
+        /// </remarks>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (!_isDisposed)
+            {
+                lock (_lock)
+                {
+                    _isDisposed = true;
+                    Monitor.Pulse(_lock);
+                }
+            }
+        }
+
+        private ObjectDisposedException CreateObjectDisposedException()
+        {
+            return new ObjectDisposedException(GetType().FullName);
+        }
+    }
+
+    internal class PipeEntry
+    {
+        private readonly byte[] _data;
+        public int Position;
+        public int Length;
+
+        public PipeEntry(byte[] data, int offset, int count)
+        {
+            _data = data;
+            Position = offset;
+            Length = count;
+        }
+
+        public int Read(byte[] dst, int offset, int count)
+        {
+            var bytesToCopy = count;
+            var bytesAvailable = Length - Position;
+
+            if (count > bytesAvailable)
+                bytesToCopy = bytesAvailable;
+
+            Buffer.BlockCopy(_data, Position, dst, offset, bytesToCopy);
+            Position += bytesToCopy;
+            return bytesToCopy;
+        }
+
+        public bool IsEmpty
+        {
+            get { return Position == Length; }
+        }
+
+        public PipeEntry Next { get; set; }
+    }
+}

--- a/PipeBench.csproj
+++ b/PipeBench.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -32,6 +32,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LinkedListPipeStream.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BufferingPipeStream.cs" />

--- a/Program.cs
+++ b/Program.cs
@@ -60,6 +60,7 @@ namespace PipeBench
             Test(new BlockingPipeStream());
             Test(new BufferingPipeStream());
             Test(new CompatBufferingPipeStream());
+            Test(new LinkedListPipeStream());
         }
     }
 }


### PR DESCRIPTION
With this, I get the following results on Windows 10 / .NET 4.5:

```
BlockingPipeStream test starting.
BlockingPipeStream test wrote 65536000000 bytes in 1000000 iterations.
BlockingPipeStream test read 65536000000 bytes in 13,267 seconds.
BufferingPipeStream test starting.
BufferingPipeStream test wrote 65536000000 bytes in 1000000 iterations.
BufferingPipeStream test read 65536000000 bytes in 8,726 seconds.
CompatBufferingPipeStream test starting.
CompatBufferingPipeStream test wrote 65536000000 bytes in 1000000 iterations.
CompatBufferingPipeStream test read 65536000000 bytes in 8,159 seconds.
LinkedListPipeStream test starting.
LinkedListPipeStream test wrote 65536000000 bytes in 1000000 iterations.
LinkedListPipeStream test read 65536000000 bytes in 2,004 seconds.
```

Note:
Do not focus on the **LinkedListPipeStream** result.
It may very well be bugged.
